### PR TITLE
フォームログイン処理の改善

### DIFF
--- a/src/main/kotlin/com/book/manager/application/service/AuthenticationService.kt
+++ b/src/main/kotlin/com/book/manager/application/service/AuthenticationService.kt
@@ -6,7 +6,5 @@ import org.springframework.stereotype.Service
 
 @Service
 class AuthenticationService(private val accountRepository: AccountRepository) {
-    fun findAccount(email: String): Account? {
-        return accountRepository.findByEmail(email)
-    }
+    fun findAccount(email: String): Account? = accountRepository.findByEmail(email)
 }

--- a/src/main/kotlin/com/book/manager/application/service/security/BookManagerUserDetailsService.kt
+++ b/src/main/kotlin/com/book/manager/application/service/security/BookManagerUserDetailsService.kt
@@ -7,13 +7,15 @@ import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.AuthorityUtils
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.core.userdetails.UsernameNotFoundException
 
 class BookManagerUserDetailsService(private val authenticationService: AuthenticationService) : UserDetailsService {
 
-    override fun loadUserByUsername(username: String): UserDetails? {
-        val account = authenticationService.findAccount(username)
-        return account?.let { BookManagerUserDetails(account) }
-    }
+    override fun loadUserByUsername(username: String): UserDetails =
+        when (val account = authenticationService.findAccount(username)) {
+            null -> throw UsernameNotFoundException("無効なユーザー名です $username")
+            else -> BookManagerUserDetails(account)
+        }
 }
 
 data class BookManagerUserDetails(

--- a/src/main/kotlin/com/book/manager/presentation/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/book/manager/presentation/config/SecurityConfig.kt
@@ -7,11 +7,14 @@ import com.book.manager.presentation.handler.BookManagerAccessDeniedHandler
 import com.book.manager.presentation.handler.BookManagerAuthenticationEntryPoint
 import com.book.manager.presentation.handler.BookManagerAuthenticationFailureHandler
 import com.book.manager.presentation.handler.BookManagerAuthenticationSuccessHandler
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
@@ -19,6 +22,15 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @EnableWebSecurity
 class SecurityConfig(private val authenticationService: AuthenticationService) : WebSecurityConfigurerAdapter() {
+
+    // Accountのパスワードをエンコードする際に必要となるのでBeanにする
+    @Bean
+    fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
+
+    // パスワード認証時 `configure(AuthenticationManagerBuilder)` にエンコードするのでDI
+    @Autowired
+    private lateinit var passwordEncoder: PasswordEncoder
+
     override fun configure(http: HttpSecurity) {
         http.authorizeRequests()
             .mvcMatchers("/greeter/**").permitAll()
@@ -47,7 +59,7 @@ class SecurityConfig(private val authenticationService: AuthenticationService) :
 
     override fun configure(auth: AuthenticationManagerBuilder) {
         auth.userDetailsService(BookManagerUserDetailsService(authenticationService))
-            .passwordEncoder(BCryptPasswordEncoder())
+            .passwordEncoder(passwordEncoder)
     }
 
     private fun corsConfigurationSource(): CorsConfigurationSource {

--- a/src/test/kotlin/com/book/manager/application/service/security/BookManagerUserDetailsServiceTest.kt
+++ b/src/test/kotlin/com/book/manager/application/service/security/BookManagerUserDetailsServiceTest.kt
@@ -5,12 +5,15 @@ import com.book.manager.domain.enum.RoleType
 import com.book.manager.domain.model.Account
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.core.userdetails.UsernameNotFoundException
 
 internal class BookManagerUserDetailsServiceTest {
 
@@ -24,17 +27,21 @@ internal class BookManagerUserDetailsServiceTest {
     }
 
     @Test
-    @DisplayName("アカウントが無ければNullを返す")
+    @DisplayName("アカウントが無ければ UsernameNotFoundExceptionを返す")
     fun `loadUserByUsername when account is null then return null`() {
 
         // Given
+        val username = "invalidUser"
         whenever(authenticationService.findAccount(any() as String)).thenReturn(null)
 
         // When
-        val result = bookManagerUserDetailsService.loadUserByUsername("user")
+        val result = assertThrows<UsernameNotFoundException> {
+            bookManagerUserDetailsService.loadUserByUsername(username)
+        }
 
         // Then
-        assertThat(result).isNull()
+        verify(authenticationService).findAccount(username)
+        assertThat(result.message).isEqualTo("無効なユーザー名です $username")
     }
 
     @Test

--- a/src/test/kotlin/com/book/manager/presentation/config/FormLoginTest.kt
+++ b/src/test/kotlin/com/book/manager/presentation/config/FormLoginTest.kt
@@ -1,0 +1,135 @@
+package com.book.manager.presentation.config
+
+import com.book.manager.application.service.AdminBookService
+import com.book.manager.application.service.AuthenticationService
+import com.book.manager.application.service.mockuser.WithCustomMockUser
+import com.book.manager.domain.enum.RoleType
+import com.book.manager.domain.model.Account
+import com.book.manager.presentation.controller.AdminBookController
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.formLogin
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated
+import org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.unauthenticated
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(controllers = [AdminBookController::class])
+internal class FormLoginTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var passwordEncoder: PasswordEncoder
+
+    @MockBean
+    private lateinit var authenticationService: AuthenticationService
+
+    // AdminBookはUSERロールではアクセス出来ない仕様なのでテスト
+    @MockBean
+    private lateinit var adminBookService: AdminBookService
+
+    @Test
+    @DisplayName("ユーザー名とパスワードが一致すればログイン認証に成功する")
+    fun `formLogin when account exists then success authentication`() {
+
+        // Given
+        val email = "test@example.com"
+        val pass = "passpass"
+        val role = RoleType.USER
+
+        val account = Account(1, email, passwordEncoder.encode(pass), "test", role)
+        whenever(authenticationService.findAccount(any() as String)).thenReturn(account)
+
+        // When
+        mockMvc
+            .perform(
+                formLogin()
+                    .loginProcessingUrl("/login")
+                    .user("email", email)
+                    .password("pass", pass)
+            )
+            .andExpect(authenticated().withUsername(email))
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    @DisplayName("パスワードが違うとログイン認証に失敗する")
+    fun `formLogin when password is incorrectly then failure authentication`() {
+
+        // Given
+        val email = "test@example.com"
+        val pass = "passpass"
+        val role = RoleType.USER
+        val account =
+            Account(1, email, passwordEncoder.encode(pass), "test", role)
+        whenever(authenticationService.findAccount(any() as String)).thenReturn(account)
+
+        // When
+        mockMvc
+            .perform(
+                formLogin()
+                    .loginProcessingUrl("/login")
+                    .user("email", email)
+                    .password("pass", "invalid")
+            )
+            .andExpect(unauthenticated())
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    @DisplayName("登録されていないユーザー名ならログイン認証に失敗する")
+    fun `formLogin when account does not exist then failure authentication`() {
+
+        // Given
+        whenever(authenticationService.findAccount(any() as String)).thenReturn(null)
+
+        // When
+        mockMvc
+            .perform(
+                formLogin()
+                    .loginProcessingUrl("/login")
+                    .user("email", "unregister")
+                    .password("pass", "invalid")
+            )
+            .andExpect(unauthenticated())
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    @DisplayName("認証されていなければアクセスできない")
+    fun `exceptionHandling when account does not authenticate then can not access except login`() {
+
+        // When
+        mockMvc
+            .perform(
+                delete("/admin/book/delete/100")
+                    .with(csrf().asHeader())
+            )
+            .andExpect(unauthenticated())
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    @DisplayName("認証アカウントが権限を持たなければアクセスできない")
+    @WithCustomMockUser(roleType = RoleType.USER)
+    fun `exceptionHandling when account has not authorization then can not access`() {
+
+        // When
+        mockMvc
+            .perform(
+                delete("/admin/book/delete/200")
+                    .with(csrf().asHeader())
+            )
+            .andExpect(status().isForbidden)
+    }
+}


### PR DESCRIPTION
フォームログインのUnitTestを実施し、パスワードエンコーダのコンテナ登録と未登録アカウント検索時の例外ハンドリングを追加しました。