### PR TITLE
IntegrationTestタスクの追加

### DIFF
--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -63,7 +63,7 @@ jobs:
 
       # Build with Gradle
       - name: Build with Gradle
-        run: ./gradlew clean test jacocoTestReport
+        run: ./gradlew clean check jacocoTestReport
 
       # Test Reportをアーカイブする
       - name: Archive Test Reports

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,7 +103,7 @@ configurations {
     getByName("${integrationDirName}RuntimeOnly").extendsFrom(configurations.testRuntimeOnly.get())
 }
 
-val integrationTest = task<Test>("integrationTest") {
+val integrationTest = task<Test>("${integrationDirName}Test") {
     description = "Runs integration tests."
     group = "verification"
     testClassesDirs = sourceSets.getByName(integrationDirName).output.classesDirs
@@ -118,8 +118,8 @@ tasks.check {
 idea {
     module {
         sourceSets[integrationDirName].let {
-            testSourceDirs.plusAssign(it.allSource)
-            testResourceDirs.plusAssign(it.resources)
+            testSourceDirs = testSourceDirs.plus(it.allSource.srcDirs)
+            testResourceDirs = testResourceDirs.plus(it.resources.srcDirs)
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,8 +99,11 @@ sourceSets {
 }
 
 configurations {
-    getByName("${integrationDirName}Implementation").extendsFrom(configurations.testImplementation.get())
     getByName("${integrationDirName}RuntimeOnly").extendsFrom(configurations.testRuntimeOnly.get())
+}
+
+val integrationImplementation: Configuration by configurations.getting {
+    extendsFrom(configurations.testImplementation.get())
 }
 
 val integrationTest = task<Test>("${integrationDirName}Test") {
@@ -113,15 +116,6 @@ val integrationTest = task<Test>("${integrationDirName}Test") {
 
 tasks.check {
     dependsOn(integrationTest)
-}
-
-idea {
-    module {
-        sourceSets[integrationDirName].let {
-            testSourceDirs = testSourceDirs.plus(it.allSource.srcDirs)
-            testResourceDirs = testResourceDirs.plus(it.resources.srcDirs)
-        }
-    }
 }
 
 mybatisGenerator {
@@ -147,6 +141,15 @@ protobuf {
                 id("grpc")
                 id("grpckt")
             }
+        }
+    }
+}
+
+idea {
+    module {
+        project.sourceSets[integrationDirName].let {
+            testSourceDirs = testSourceDirs.plus(it.allSource.srcDirs)
+            testResourceDirs = testResourceDirs.plus(it.resources.srcDirs)
         }
     }
 }

--- a/src/integration/kotlin/com/book/manager/BookManagerIntegrationTests.kt
+++ b/src/integration/kotlin/com/book/manager/BookManagerIntegrationTests.kt
@@ -1,0 +1,26 @@
+package com.book.manager
+
+import com.book.manager.domain.model.Book
+import com.book.manager.domain.model.BookWithRental
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+internal class BookManagerIntegrationTests {
+
+    @Test
+    @DisplayName("疎通テスト")
+    fun smoke() {
+
+        // Given
+        val book = Book(100, "integration test", "integration", LocalDate.now())
+
+        // When
+        val bookWithRental = BookWithRental(book, null)
+
+        // Then
+        assertThat(bookWithRental.isRental).isFalse
+    }
+
+}


### PR DESCRIPTION
GradleにintegrationTestタスクを追加し、統合テスト専用のテストコードの管理とテスト実行が行えるようにしました。
integrationTestタスクはcheckタスクで testタスク完了後に実行します。