### PR TITLE
RestTemplateを使って認証・認可を考慮したテストケースサンプルを作成

### DIFF
--- a/src/test/kotlin/com/book/manager/presentation/controller/BookControllerTest.kt
+++ b/src/test/kotlin/com/book/manager/presentation/controller/BookControllerTest.kt
@@ -80,7 +80,7 @@ internal class BookControllerTest(@Autowired val mockMvc: MockMvc) {
             }
 
         val expected = GetBookListResponse(bookWithRentalList.map { BookInfo(it) })
-        assertThat(result.bookList).containsAll(expected.bookList)
+        assertThat(result.bookList).containsExactlyInAnyOrderElementsOf(expected.bookList)
     }
 
     @Test


### PR DESCRIPTION
ここではログイン認証を事前に行うことで、実施したいテストが行えることを確認した。
今後、RestTemplateをカスタマイズしたBeanで、この認証・認可を行うことで統合テストコードを書きやすくしていく。