### PR TITLE
IntegrationTest用のTestRestTemplateを実装

### DIFF
--- a/src/integration/kotlin/com/book/manager/presentation/config/IntegrationTestConfiguration.kt
+++ b/src/integration/kotlin/com/book/manager/presentation/config/IntegrationTestConfiguration.kt
@@ -1,7 +1,10 @@
 package com.book.manager.presentation.config
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 
 @TestConfiguration
 class IntegrationTestConfiguration {
@@ -9,5 +12,15 @@ class IntegrationTestConfiguration {
     @Bean
     fun integrationTestRestTemplate(): IntegrationTestRestTemplate {
         return IntegrationTestRestTemplate()
+    }
+
+    // TestRestTemplateを継承したクラスを使うとjackson-module-kotlinのConverterが効かなくなるためBeanを用意する
+    @Bean
+    fun mappingJackson2HttpMessageConverter(): MappingJackson2HttpMessageConverter {
+        return MappingJackson2HttpMessageConverter().apply {
+            this.objectMapper = ObjectMapper().apply {
+                registerKotlinModule()
+            }
+        }
     }
 }

--- a/src/integration/kotlin/com/book/manager/presentation/config/IntegrationTestConfiguration.kt
+++ b/src/integration/kotlin/com/book/manager/presentation/config/IntegrationTestConfiguration.kt
@@ -1,0 +1,13 @@
+package com.book.manager.presentation.config
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+
+@TestConfiguration
+class IntegrationTestConfiguration {
+
+    @Bean
+    fun integrationTestRestTemplate(): IntegrationTestRestTemplate {
+        return IntegrationTestRestTemplate()
+    }
+}

--- a/src/integration/kotlin/com/book/manager/presentation/config/IntegrationTestRestTemplate.kt
+++ b/src/integration/kotlin/com/book/manager/presentation/config/IntegrationTestRestTemplate.kt
@@ -1,0 +1,38 @@
+package com.book.manager.presentation.config
+
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.RequestEntity
+import org.springframework.http.ResponseEntity
+import org.springframework.util.LinkedMultiValueMap
+import java.net.URI
+
+class IntegrationTestRestTemplate : TestRestTemplate() {
+
+    fun login(port: Int, _user: String?, _pass: String?): ResponseEntity<String> {
+        val user = _user ?: "user@example.com"
+        val pass = _pass ?: "user"
+
+        val loginForm = LinkedMultiValueMap<String, String>().apply {
+            add("email", user)
+            add("pass", pass)
+        }
+
+        val request = RequestEntity
+            .post(URI.create("http://localhost:$port/login"))
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .accept(MediaType.TEXT_HTML)
+            .body(loginForm)
+
+        return restTemplate.exchange(request, String::class.java)
+    }
+
+    fun preLogin(port: Int, _user: String?, _pass: String?): HttpHeaders {
+        val response = login(port, _user, _pass)
+        val cookies = response.headers[HttpHeaders.SET_COOKIE]
+        val httpHeaders = HttpHeaders()
+        cookies?.forEach { httpHeaders.add("Cookie", it) }
+        return httpHeaders
+    }
+}

--- a/src/integration/kotlin/com/book/manager/presentation/config/IntegrationTestRestTemplate.kt
+++ b/src/integration/kotlin/com/book/manager/presentation/config/IntegrationTestRestTemplate.kt
@@ -10,9 +10,7 @@ import java.net.URI
 
 class IntegrationTestRestTemplate : TestRestTemplate() {
 
-    fun login(port: Int, _user: String?, _pass: String?): ResponseEntity<String> {
-        val user = _user ?: "user@example.com"
-        val pass = _pass ?: "user"
+    fun login(port: Int, user: String? = "user@example.com", pass: String? = "user"): ResponseEntity<String> {
 
         val loginForm = LinkedMultiValueMap<String, String>().apply {
             add("email", user)
@@ -28,8 +26,8 @@ class IntegrationTestRestTemplate : TestRestTemplate() {
         return restTemplate.exchange(request, String::class.java)
     }
 
-    fun preLogin(port: Int, _user: String?, _pass: String?): HttpHeaders {
-        val response = login(port, _user, _pass)
+    fun getHeaderAfterLogin(port: Int, user: String?, pass: String?): HttpHeaders {
+        val response = login(port, user, pass)
         val cookies = response.headers[HttpHeaders.SET_COOKIE]
         val httpHeaders = HttpHeaders()
         cookies?.forEach { httpHeaders.add("Cookie", it) }


### PR DESCRIPTION
各リクエストに対する検証を行う場合に、ログイン認証を通してセッション情報とCSRFトークンをCookieにセットしておかなければならないので、この処理を汎用化したTestRestTemplateを用意しました。