### PR TITLE
TRestTemplateをカスタムのRestTemplateBuilderから生成するように変更

### DIFF
--- a/src/integration/kotlin/com/book/manager/BookManagerIntegrationTests.kt
+++ b/src/integration/kotlin/com/book/manager/BookManagerIntegrationTests.kt
@@ -24,9 +24,6 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.boot.web.server.LocalServerPort
 import org.springframework.context.annotation.Import
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import java.time.LocalDate
@@ -86,8 +83,6 @@ internal class BookManagerIntegrationTests : TestContainerDataRegistry() {
 
         // Then
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        // CookieにセットされるSESSIONとXSRF-TOKENを出力しておく
-        response.headers[HttpHeaders.SET_COOKIE]?.map { it.split(";")[0] }?.forEach { println(it) }
     }
 
     @Test
@@ -109,15 +104,10 @@ internal class BookManagerIntegrationTests : TestContainerDataRegistry() {
 
         val user = "admin@example.com"
         val pass = "admin"
-        val httpHeaders = restTemplate.getHeaderAfterLogin(port, user, pass)
+        restTemplate.login(port, user, pass)
 
         // When
-        val response = restTemplate.exchange(
-            "http://localhost:$port/book/list",
-            HttpMethod.GET,
-            HttpEntity<String>(httpHeaders),
-            GetBookListResponse::class.java
-        )
+        val response = restTemplate.getForEntity("http://localhost:$port/book/list", GetBookListResponse::class.java)
 
         // Then
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)

--- a/src/integration/kotlin/com/book/manager/presentation/config/CustomClientHttpRequestInterceptor.kt
+++ b/src/integration/kotlin/com/book/manager/presentation/config/CustomClientHttpRequestInterceptor.kt
@@ -1,0 +1,38 @@
+package com.book.manager.presentation.config
+
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpRequest
+import org.springframework.http.client.ClientHttpRequestExecution
+import org.springframework.http.client.ClientHttpRequestInterceptor
+import org.springframework.http.client.ClientHttpResponse
+import java.net.HttpCookie
+
+private val logger: Logger = LogManager.getLogger(CustomClientHttpRequestInterceptor::class)
+
+class CustomClientHttpRequestInterceptor : ClientHttpRequestInterceptor {
+
+    private var cookies = mutableMapOf<String, HttpCookie>()
+
+    override fun intercept(
+        request: HttpRequest,
+        body: ByteArray,
+        execution: ClientHttpRequestExecution
+    ): ClientHttpResponse {
+
+        // Requestヘッダーに直前のResponseヘッダーのCookieをセットしてから送信する
+        val cookiesForRequest = cookies.values.map { it.toString() }.toList()
+        logger.info("Using cookies: $cookiesForRequest")
+        request.headers.addAll(HttpHeaders.COOKIE, cookiesForRequest)
+
+        logger.info("Request: uri=${request.uri}, headers=${request.headers}, body=${String(body)}")
+        val response = execution.execute(request, body)
+
+        val cookiesFromResponse = response.headers[HttpHeaders.SET_COOKIE]?.flatMap { HttpCookie.parse(it) }
+        logger.info("Extracted cookies from response: $cookiesFromResponse")
+        cookiesFromResponse?.forEach { cookies[it.name] = it }
+
+        return response
+    }
+}

--- a/src/integration/kotlin/com/book/manager/presentation/config/CustomRestTemplateCustomizer.kt
+++ b/src/integration/kotlin/com/book/manager/presentation/config/CustomRestTemplateCustomizer.kt
@@ -1,0 +1,10 @@
+package com.book.manager.presentation.config
+
+import org.springframework.boot.web.client.RestTemplateCustomizer
+import org.springframework.web.client.RestTemplate
+
+class CustomRestTemplateCustomizer : RestTemplateCustomizer {
+    override fun customize(restTemplate: RestTemplate?) {
+        restTemplate?.interceptors?.add(CustomClientHttpRequestInterceptor())
+    }
+}

--- a/src/integration/kotlin/com/book/manager/presentation/config/IntegrationTestConfiguration.kt
+++ b/src/integration/kotlin/com/book/manager/presentation/config/IntegrationTestConfiguration.kt
@@ -3,6 +3,7 @@ package com.book.manager.presentation.config
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 
@@ -11,7 +12,8 @@ class IntegrationTestConfiguration {
 
     @Bean
     fun integrationTestRestTemplate(): IntegrationTestRestTemplate {
-        return IntegrationTestRestTemplate()
+        val builder = RestTemplateBuilder(CustomRestTemplateCustomizer())
+        return IntegrationTestRestTemplate(builder)
     }
 
     // TestRestTemplateを継承したクラスを使うとjackson-module-kotlinのConverterが効かなくなるためBeanを用意する

--- a/src/integration/kotlin/com/book/manager/presentation/config/IntegrationTestRestTemplate.kt
+++ b/src/integration/kotlin/com/book/manager/presentation/config/IntegrationTestRestTemplate.kt
@@ -1,14 +1,14 @@
 package com.book.manager.presentation.config
 
 import org.springframework.boot.test.web.client.TestRestTemplate
-import org.springframework.http.HttpHeaders
+import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.http.MediaType
 import org.springframework.http.RequestEntity
 import org.springframework.http.ResponseEntity
 import org.springframework.util.LinkedMultiValueMap
 import java.net.URI
 
-class IntegrationTestRestTemplate : TestRestTemplate() {
+class IntegrationTestRestTemplate(builder: RestTemplateBuilder) : TestRestTemplate(builder) {
 
     fun login(port: Int, user: String? = "user@example.com", pass: String? = "user"): ResponseEntity<String> {
 
@@ -24,13 +24,5 @@ class IntegrationTestRestTemplate : TestRestTemplate() {
             .body(loginForm)
 
         return restTemplate.exchange(request, String::class.java)
-    }
-
-    fun getHeaderAfterLogin(port: Int, user: String?, pass: String?): HttpHeaders {
-        val response = login(port, user, pass)
-        val cookies = response.headers[HttpHeaders.SET_COOKIE]
-        val httpHeaders = HttpHeaders()
-        cookies?.forEach { httpHeaders.add("Cookie", it) }
-        return httpHeaders
     }
 }


### PR DESCRIPTION
カスタムビルダーでは、Cookie情報の受け渡しを行う処理を追加しています。 
カスタムビルダーを用意しておくことで、各種設定を追加・編集できるようになります。
 各テストコードでは前提処理としてITRestTemplateのlogin()を呼ぶだけで明示的にHeaderを編集することなく、認証済みの状態でテスト対象のリクエストを送信することができるようになります。