### PR TITLE
書籍の登録テストを追加

### DIFF
--- a/src/integration/kotlin/com/book/manager/presentation/config/CustomClientHttpRequestInterceptor.kt
+++ b/src/integration/kotlin/com/book/manager/presentation/config/CustomClientHttpRequestInterceptor.kt
@@ -40,6 +40,4 @@ class CustomClientHttpRequestInterceptor : ClientHttpRequestInterceptor {
 
         return response
     }
-
-
 }

--- a/src/integration/kotlin/com/book/manager/presentation/config/IntegrationTestConfiguration.kt
+++ b/src/integration/kotlin/com/book/manager/presentation/config/IntegrationTestConfiguration.kt
@@ -1,11 +1,8 @@
 package com.book.manager.presentation.config
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.context.annotation.Bean
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 
 @TestConfiguration
 class IntegrationTestConfiguration {
@@ -14,15 +11,5 @@ class IntegrationTestConfiguration {
     fun integrationTestRestTemplate(): IntegrationTestRestTemplate {
         val builder = RestTemplateBuilder(CustomRestTemplateCustomizer())
         return IntegrationTestRestTemplate(builder)
-    }
-
-    // TestRestTemplateを継承したクラスを使うとjackson-module-kotlinのConverterが効かなくなるためBeanを用意する
-    @Bean
-    fun mappingJackson2HttpMessageConverter(): MappingJackson2HttpMessageConverter {
-        return MappingJackson2HttpMessageConverter().apply {
-            this.objectMapper = ObjectMapper().apply {
-                registerKotlinModule()
-            }
-        }
     }
 }

--- a/src/integration/kotlin/com/book/manager/presentation/config/IntegrationTestRestTemplate.kt
+++ b/src/integration/kotlin/com/book/manager/presentation/config/IntegrationTestRestTemplate.kt
@@ -1,5 +1,9 @@
 package com.book.manager.presentation.config
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.http.MediaType
@@ -24,5 +28,13 @@ class IntegrationTestRestTemplate(builder: RestTemplateBuilder) : TestRestTempla
             .body(loginForm)
 
         return restTemplate.exchange(request, String::class.java)
+    }
+
+    fun <T> jsonStringToObject(json: String, obj: Class<T>): T {
+        return ObjectMapper()
+            .registerKotlinModule()
+            .registerModule(JavaTimeModule())
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+            .readValue(json, obj)
     }
 }


### PR DESCRIPTION
統合テストとして、RestTemplateを使った登録を検査できるようにした。
POSTメソッドでCSRF Tokenがセットできるようにし、RequestBodyのJsonをオブジェクトに変換し、実行結果もJsonからオブジェクトに変換して検証できるようにした。