### PR TITLE
Dcokerイメージのバージョンを更新しました

### DIFF
--- a/docker/postgresql/Dockerfile
+++ b/docker/postgresql/Dockerfile
@@ -1,3 +1,3 @@
-FROM postgres:14-bullseye
+FROM postgres:14
 
 COPY ./docker/postgresql/initdb /docker-entrypoint-initdb.d

--- a/src/test/kotlin/com/book/manager/infrastructure/database/testcontainers/TestContainerDataRegistry.kt
+++ b/src/test/kotlin/com/book/manager/infrastructure/database/testcontainers/TestContainerDataRegistry.kt
@@ -12,7 +12,7 @@ abstract class TestContainerDataRegistry {
 
     companion object {
         @JvmStatic
-        val database = PostgreSQLContainer<Nothing>(DockerImageName.parse("postgres")).apply {
+        val database = PostgreSQLContainer<Nothing>(DockerImageName.parse("postgres:14-alpine")).apply {
             withDatabaseName("test")
             withUsername("user")
             withPassword("pass")
@@ -23,7 +23,7 @@ abstract class TestContainerDataRegistry {
         }
 
         @JvmStatic
-        val redis: GenericContainer<*> = GenericContainer<Nothing>(DockerImageName.parse("redis")).apply {
+        val redis: GenericContainer<*> = GenericContainer<Nothing>(DockerImageName.parse("redis:7-alpine")).apply {
             withExposedPorts(6379)
             start()
         }


### PR DESCRIPTION
PostgreSQLはbullseye(Debian系)を指定していたのを取りやめました

- TestContainersで使うイメージはalpineにしました