### PR TITLE
FormLoginTestを修正した

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,8 +39,8 @@ dependencies {
     implementation("org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.2")
     implementation("org.mybatis.dynamic-sql:mybatis-dynamic-sql:1.4.0")
     implementation("redis.clients:jedis")
-    implementation("io.grpc:grpc-kotlin-stub:1.2.1")
-    implementation("io.grpc:grpc-netty:1.46.0")
+    implementation("io.grpc:grpc-kotlin-stub:1.3.0")
+    implementation("io.grpc:grpc-netty:1.47.0")
     implementation("io.github.lognet:grpc-spring-boot-starter:4.7.0")
     runtimeOnly("org.postgresql:postgresql")
     mybatisGenerator("org.mybatis.generator:mybatis-generator-core:1.4.1")
@@ -52,9 +52,9 @@ dependencies {
     testImplementation("org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2")
     testImplementation("com.github.springtestdbunit:spring-test-dbunit:1.3.0")
     testImplementation("org.dbunit:dbunit:2.7.3")
-    testImplementation("org.testcontainers:testcontainers:1.17.1")
-    testImplementation("org.testcontainers:junit-jupiter:1.17.1")
-    testImplementation("org.testcontainers:postgresql:1.17.1")
+    testImplementation("org.testcontainers:testcontainers:1.17.2")
+    testImplementation("org.testcontainers:junit-jupiter:1.17.2")
+    testImplementation("org.testcontainers:postgresql:1.17.2")
 }
 
 configurations {

--- a/src/test/kotlin/com/book/manager/presentation/config/SecurityConfigTest.kt
+++ b/src/test/kotlin/com/book/manager/presentation/config/SecurityConfigTest.kt
@@ -13,7 +13,6 @@ import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.formLogin
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
@@ -24,8 +23,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@ContextConfiguration(classes = [SecurityConfig::class])
-@Import(BookManagerUserDetailsService::class)
+@ContextConfiguration(classes = [SecurityConfig::class, BookManagerUserDetailsService::class])
 @WebMvcTest(controllers = [AdminBookController::class])
 internal class SecurityConfigTest(@Autowired val mockMvc: MockMvc) {
 

--- a/src/test/kotlin/com/book/manager/presentation/config/SecurityConfigTest.kt
+++ b/src/test/kotlin/com/book/manager/presentation/config/SecurityConfigTest.kt
@@ -2,10 +2,10 @@ package com.book.manager.presentation.config
 
 import com.book.manager.application.service.AuthenticationService
 import com.book.manager.application.service.mockuser.WithCustomMockUser
+import com.book.manager.application.service.security.BookManagerUserDetailsService
 import com.book.manager.domain.enum.RoleType
 import com.book.manager.domain.model.Account
 import com.book.manager.presentation.controller.AdminBookController
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -13,6 +13,7 @@ import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.formLogin
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
@@ -23,8 +24,9 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@WebMvcTest(controllers = [AdminBookController::class])
 @ContextConfiguration(classes = [SecurityConfig::class])
+@Import(BookManagerUserDetailsService::class)
+@WebMvcTest(controllers = [AdminBookController::class])
 internal class SecurityConfigTest(@Autowired val mockMvc: MockMvc) {
 
     @Autowired
@@ -33,7 +35,6 @@ internal class SecurityConfigTest(@Autowired val mockMvc: MockMvc) {
     @MockBean
     private lateinit var authenticationService: AuthenticationService
 
-    @Disabled
     @Test
     @DisplayName("ユーザー名とパスワードが一致すればログイン認証に成功する")
     fun `formLogin when account exists then success authentication`() {


### PR DESCRIPTION
## これは何？

SpringSercurityを5系に上げて、Security設定を `SecurityFilterChain`に変えた所、`formLogin()`テストで認証できなくなってしまったので修正した


## やったこと

`SecurityConfigTest` に `@ContextConfiguration`を使って、SecurityConfigとBookManagerUserDetailsSeriviceのBeanをLoadするよう

BookManagerUserDetailsServiceをLoadしていないと、認証プロバイダでデフォルトのInMemoryUserDetailsManagerが利用されてしまう。

