### PR TITLE
CSRFトークンのハンドリングを改善した

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     kotlin("jvm") version "1.7.22"
     kotlin("plugin.spring") version "1.7.22"
     id("org.springframework.boot") version "3.0.0"
-    id("io.spring.dependency-management") version "1.0.14.RELEASE"
+    id("io.spring.dependency-management") version "1.1.0"
     id("com.thinkimi.gradle.MybatisGenerator") version "2.4"
     id("jacoco")
     id("com.google.protobuf") version "0.9.1"

--- a/src/integration/kotlin/com/book/manager/config/CustomClientHttpRequestInterceptor.kt
+++ b/src/integration/kotlin/com/book/manager/config/CustomClientHttpRequestInterceptor.kt
@@ -15,6 +15,7 @@ class CustomClientHttpRequestInterceptor : ClientHttpRequestInterceptor {
 
     private var sessionId = ""
     private var csrfToken = ""
+    private var csrfHeader = ""
 
     // 認証エラーとならないようにセッションIDとCSRFトークンをリクエストにセットする
     override fun intercept(
@@ -29,8 +30,8 @@ class CustomClientHttpRequestInterceptor : ClientHttpRequestInterceptor {
         }
 
         if (csrfToken != "") {
-            logger.info("Set Request Header X-CSRF-TOKEN: $csrfToken")
-            request.headers["X-CSRF-TOKEN"] = csrfToken
+            logger.info("Set Request Header $csrfHeader: $csrfToken")
+            request.headers[csrfHeader] = csrfToken
         }
 
         logger.info("Request: uri=${request.uri}, headers=${request.headers}, body=${String(body)}")
@@ -47,6 +48,10 @@ class CustomClientHttpRequestInterceptor : ClientHttpRequestInterceptor {
         if (response.headers.containsKey("_csrf")) {
             logger.info("Extracted CSRF-TOKEN from response: ${response.headers["_csrf"]?.get(0)}")
             csrfToken = response.headers["_csrf"]?.get(0).toString()
+        }
+        if (response.headers.containsKey("_csrf_header")) {
+            logger.info("Extracted CSRF-HEADER from response: ${response.headers["_csrf_header"]?.get(0)}")
+            csrfHeader = response.headers["_csrf_header"]?.get(0).toString()
         }
         return response
     }

--- a/src/main/kotlin/com/book/manager/presentation/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/book/manager/presentation/config/SecurityConfig.kt
@@ -27,30 +27,27 @@ class SecurityConfig {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
 
-        http.authorizeHttpRequests { authorize ->
-            authorize
-                .requestMatchers("/greeter/**", "/csrf_token").permitAll()
-                .requestMatchers("/admin/**").hasAuthority(RoleType.ADMIN.toString())
-                .anyRequest().authenticated()
-        }.formLogin { login ->
-            login
-                .loginProcessingUrl("/login").permitAll()
-                .usernameParameter("email")
-                .passwordParameter("pass")
-                .successHandler(BookManagerAuthenticationSuccessHandler())
-                .failureHandler(BookManagerAuthenticationFailureHandler())
+        http.authorizeHttpRequests {
+            it.requestMatchers("/greeter/**", "/csrf_token").permitAll()
+            it.requestMatchers("/admin/**").hasAuthority(RoleType.ADMIN.toString())
+            it.anyRequest().authenticated()
+        }.formLogin {
+            it.loginProcessingUrl("/login").permitAll()
+            it.usernameParameter("email")
+            it.passwordParameter("pass")
+            it.successHandler(BookManagerAuthenticationSuccessHandler())
+            it.failureHandler(BookManagerAuthenticationFailureHandler())
         }.logout {
             it.logoutUrl("/logout")
             it.logoutSuccessHandler(HttpStatusReturningLogoutSuccessHandler())
             it.invalidateHttpSession(true)
             it.deleteCookies("SESSION")
-        }.exceptionHandling { ex ->
-            ex
-                .authenticationEntryPoint(BookManagerAuthenticationEntryPoint())
-                .accessDeniedHandler(BookManagerAccessDeniedHandler())
+        }.exceptionHandling {
+            it.authenticationEntryPoint(BookManagerAuthenticationEntryPoint())
+            it.accessDeniedHandler(BookManagerAccessDeniedHandler())
         }.csrf {
-        }.cors { cors ->
-            cors.configurationSource(corsConfigurationSource())
+        }.cors {
+            it.configurationSource(corsConfigurationSource())
         }
         return http.build()
     }

--- a/src/main/kotlin/com/book/manager/presentation/controller/CsrfTokenController.kt
+++ b/src/main/kotlin/com/book/manager/presentation/controller/CsrfTokenController.kt
@@ -1,20 +1,19 @@
 package com.book.manager.presentation.controller
 
+import com.book.manager.presentation.security.CsrfTokenHandler
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.springframework.security.web.csrf.CsrfToken
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @CrossOrigin
-class CsrfTokenController() {
+class CsrfTokenController {
 
     @GetMapping("/csrf_token")
     fun csrfToken(request: HttpServletRequest, response: HttpServletResponse): String {
-        val csrfToken = request.getAttribute("_csrf") as CsrfToken
-        response.setHeader("_csrf", csrfToken.token)
-        return "Get CSRF TOKEN"
+        CsrfTokenHandler(request, response).setToken()
+        return "Send Token!"
     }
 }

--- a/src/main/kotlin/com/book/manager/presentation/handler/BookManagerAuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/book/manager/presentation/handler/BookManagerAuthenticationSuccessHandler.kt
@@ -1,10 +1,10 @@
 package com.book.manager.presentation.handler
 
+import com.book.manager.presentation.security.CsrfTokenHandler
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.security.core.Authentication
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler
-import org.springframework.security.web.csrf.CsrfToken
 
 class BookManagerAuthenticationSuccessHandler : AuthenticationSuccessHandler {
     override fun onAuthenticationSuccess(
@@ -13,8 +13,7 @@ class BookManagerAuthenticationSuccessHandler : AuthenticationSuccessHandler {
         authentication: Authentication
     ) {
         response.status = HttpServletResponse.SC_OK
-        // 認証でセッションが書き換わるので 更新されたCSRFトークンをレスポンスヘッダにセットする
-        val csrfToken = request.getAttribute("_csrf") as CsrfToken
-        response.setHeader("_csrf", csrfToken.token)
+        // 認証でセッションが書き換わるのでCSRFトークンも更新する
+        CsrfTokenHandler(request, response).setToken()
     }
 }

--- a/src/main/kotlin/com/book/manager/presentation/security/CsrfTokenHandler.kt
+++ b/src/main/kotlin/com/book/manager/presentation/security/CsrfTokenHandler.kt
@@ -1,0 +1,14 @@
+package com.book.manager.presentation.security
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.web.csrf.CsrfToken
+
+class CsrfTokenHandler(val request: HttpServletRequest, val response: HttpServletResponse) {
+
+    fun setToken() {
+        val csrfToken = request.getAttribute("_csrf") as CsrfToken
+        response.setHeader("_csrf", csrfToken.token)
+        response.setHeader("_csrf_header", csrfToken.headerName)
+    }
+}


### PR DESCRIPTION
## Sumary

* csrfトークンをセットするヘッダ名を CsrfTokenオブジェクトから取るようにした
  * クライアント側では レスポンスヘッダから `_csrf` と `_csrf_header` の値を使って、リクエストヘッダにセットする CSRF対策トークンをセットすることを想定している
  * [参考](https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html#servlet-csrf-include-form-auto)
* サーバー側でCSRFトークンをセットするオブジェクトを作成し、GETリクエストと認証時に利用するようにした

### その他

* SecurityConfigの各設定時の変数に `it` を利用するようにした 
