### PR TITLE
IntegrationテストのJsonオブジェクト生成を見直した

### DIFF
--- a/src/integration/kotlin/com/book/manager/BookManagerIntegrationTests.kt
+++ b/src/integration/kotlin/com/book/manager/BookManagerIntegrationTests.kt
@@ -12,8 +12,7 @@ import com.book.manager.presentation.form.AdminBookResponse
 import com.book.manager.presentation.form.BookInfo
 import com.book.manager.presentation.form.GetBookDetailResponse
 import com.book.manager.presentation.form.GetBookListResponse
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.SoftAssertions
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -35,6 +34,7 @@ import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.reactive.function.BodyInserters
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.util.stream.Stream
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
@@ -186,7 +186,13 @@ internal class BookManagerIntegrationTests : TestContainerDataRegistry() {
         webClient.login(user, pass)
 
         // When
-        val jsonObject = jacksonObjectMapper().registerModule(JavaTimeModule()).writeValueAsString(book)
+        val objectMapper = ObjectMapper()
+        val jsonObject = objectMapper.createObjectNode().apply {
+            put("id", book.id)
+            put("title", book.title)
+            put("author", book.author)
+            put("release_date", book.releaseDate.format(DateTimeFormatter.ISO_DATE))
+        }.let { objectMapper.writeValueAsString(it) }
 
         val postResponse = webClient
             .post()

--- a/src/main/kotlin/com/book/manager/domain/model/Book.kt
+++ b/src/main/kotlin/com/book/manager/domain/model/Book.kt
@@ -1,11 +1,5 @@
 package com.book.manager.domain.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDate
 
-data class Book(
-    val id: Long,
-    val title: String,
-    val author: String,
-    @JsonProperty("release_date") val releaseDate: LocalDate
-)
+data class Book(val id: Long, val title: String, val author: String, val releaseDate: LocalDate)


### PR DESCRIPTION
## 概要

IntegrationTestの書籍登録テストにおいてリクエストに使うJSONをテストデータを持ったBookインスタンスから直接変換するようにしていたが、`createObjectNode`でプロパティを一つ一つセットするようにした。これに伴い Bookクラスにつけた  `@JsonProperty` を除去し、以前に戻した

## 背景

元々はオブジェクトのプロパティ名がキャメルケースで、JsonのプロパティKeyがスネークケースだったので アノテーションを付けていた

ただTestデータ用のJsonを作るために プロダクションのBookクラスに アノテーションをつけるのが嫌だった
また実際のクライアントが送信するデータもBookオブジェクトから変換するわけではないので、できる限り実際の使い方に合わせた対応にしたかった