### PR TITLE
IntegrationTestでサーバからのResponseBodyを対応するJavaオブジェクトに変換して取得できるようにした

### DIFF
--- a/src/test/kotlin/com/book/manager/config/CustomJsonConverter.kt
+++ b/src/test/kotlin/com/book/manager/config/CustomJsonConverter.kt
@@ -20,7 +20,7 @@ class CustomJsonConverter {
 
     fun <T> toJson(obj: T): String = objectMapper().writeValueAsString(obj)
 
-    private fun objectMapper() = ObjectMapper().apply {
+    fun objectMapper() = ObjectMapper().apply {
         registerKotlinModule()
         registerModule(JavaTimeModule())
         propertyNamingStrategy = PropertyNamingStrategies.SNAKE_CASE


### PR DESCRIPTION
## 概要

単体テストやIntegrationテストでは、Jacksonを使ったJson - JavaObject変換する際に、LocalDateTimeに対応できなかったり、プロパティ名のSnakeケース、Camelケース変換に対応できなかったので、一旦 ResponseBodyをStringで受けて、専用のConverterでオブジェクトに変換するようにしていた。

Integration Testは、WebTestClientに変えたことで JsonからJavaオブジェクトにデシリアライズする時のJacksonの設定を行えたので、expectBody<> で対応するJavaオブジェクトを直接取得できるようにした

## 注意事項

一箇所だけResponseをStringで受けて専用Converterを使うままとしている。
これは、テストケースの特性上 でシリアライズで例外が発生してしまうため、Nullで返して評価を継続したかったため。