### PR TITLE
SpringBoot3.0.5 へのアップデートと バックエンドサービスをコンテナで実行できるようにした

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     kotlin("jvm") version "1.8.10"
     kotlin("plugin.spring") version "1.8.10"
-    id("org.springframework.boot") version "3.0.4"
+    id("org.springframework.boot") version "3.0.5"
     id("io.spring.dependency-management") version "1.1.0"
     id("com.thinkimi.gradle.MybatisGenerator") version "2.4"
     id("jacoco")
@@ -50,11 +50,16 @@ dependencyManagement {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("org.springframework.boot:spring-boot-starter-log4j2")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-aop")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation("org.springframework.boot:spring-boot-starter-log4j2")
+    modules {
+        module("org.springframework.boot:spring-boot-starter-logging") {
+            replacedBy("org.springframework.boot:spring-boot-starter-log4j2", "Use Log4j2 instead of Logback")
+        }
+    }
     implementation("org.springframework.session:spring-session-data-redis")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
@@ -76,12 +81,6 @@ dependencies {
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
     intTestImplementation("org.springframework.boot:spring-boot-starter-webflux")
-}
-
-configurations {
-    all {
-        exclude("org.springframework.boot", "spring-boot-starter-logging")
-    }
 }
 
 tasks.withType<KotlinCompile> {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,18 @@ services:
     container_name: redis
     volumes:
       - redis_data:/data
+
+  backend:
+    build:
+      context: ./
+      dockerfile: ./docker/backend/Dockerfile
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+      - redis
+    container_name: backend
+
 volumes:
   postgresql_data:
   redis_data:

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,0 +1,11 @@
+FROM openjdk:19-slim-bullseye as build
+WORKDIR /app
+COPY . /app
+RUN ./gradlew clean bootJar
+
+
+FROM openjdk:19-slim-bullseye
+WORKDIR /app
+VOLUME /tmp
+COPY --from=build /app/build/libs/book-manager-0.0.1-SNAPSHOT.jar /app/book-manager.jar
+ENTRYPOINT ["java", "-jar", "/app/book-manager.jar", "--spring.profiles.active=docker"]

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://db:5432/book_manager
+    username: book_manager
+    password: book_manager
+  data:
+    redis:
+      host: redis
+      port: 6379
+  jackson:
+    property-naming-strategy: SNAKE_CASE
+logging:
+  level:
+    root: info
+server:
+  error:
+    include-message: always


### PR DESCRIPTION
## 概要

- アプリケーションをDockerコンテナで起動できるように、Dockerfileを作成した
- DBとRedisにコンテナからアクセスできるようにProfilesを追加した
  - DBとResitのポートは公開する必要はサービスとしてはないが、ローカルから直接アクセスしてデータを確認できるように公開している