### PR TITLE
BackendのTelemetryデータをGrafana Stackへ転送するための改善

### DIFF
--- a/docker/backend/agent/agent.yml
+++ b/docker/backend/agent/agent.yml
@@ -49,3 +49,16 @@ logs:
                 __path__: /var/logs/*.log
       clients:
         - url: http://loki:3100/loki/api/v1/push
+
+integrations:
+  postgres_exporter:
+    enabled: true
+    data_source_names:
+      - "postgresql://book_manager:book_manager@db:5432/book_manager?sslmode=disable"
+
+  redis_exporter:
+    enabled: true
+    redis_addr: "redis:6379"
+
+  prometheus_remote_write:
+    - url: http://mimir:9009/api/v1/push

--- a/docker/backend/agent/agent.yml
+++ b/docker/backend/agent/agent.yml
@@ -1,0 +1,51 @@
+server:
+  log_level: info
+
+metrics:
+  wal_directory: /etc/agent/data
+  global:
+    scrape_interval: 2s
+  configs:
+    - name: default
+      scrape_configs:
+        - job_name: "spring-actuator"
+          metrics_path: "/actuator/prometheus"
+          static_configs:
+            - targets: [ "app:8081" ]
+      remote_write:
+        - url: http://mimir:9009/api/v1/push
+          send_exemplars: true
+
+traces:
+  configs:
+    - name: default
+      receivers:
+        zipkin:
+      remote_write:
+        - endpoint: "tempo:4317"
+          insecure: true
+
+logs:
+  configs:
+    - name: default
+      positions:
+        filename: /tmp/positions.yml
+      scrape_configs:
+        - job_name: app
+          pipeline_stages:
+            - regex:
+                expression: "^(?P<timestamp>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}\\+\\d{2}:\\d{2})\\s+(?P<level>\\w+)\\s+\\[(?P<app>[\\w-]+),(?P<trace_id>[\\w-]*),(?P<span_id>[\\w-]*)\\]\\s+\\[(?P<thread>[\\w-]+)\\]\\s+(?P<classname>[\\w.-]*):\\s+(?P<message>.*)$"
+            - labels:
+                level:
+                app:
+                trace_id:
+                span_id:
+          static_configs:
+            - targets:
+                - localhost
+              labels:
+                job: app
+                host: app
+                __path__: /var/logs/*.log
+      clients:
+        - url: http://loki:3100/loki/api/v1/push

--- a/docker/backend/compose.yml
+++ b/docker/backend/compose.yml
@@ -13,18 +13,20 @@ services:
       - app
       - db_external
       - redis_external
-      - datasources_external  # otel-exporter-zipkin で Tempoにアクセスするため
+#      - datasources_external  # otel-exporter-zipkin で Tempoにアクセスするため
     ports:
       - "8080:8080"
       - "8081:8081"
-  promtail:
-    image: grafana/promtail
-    container_name: promtail
-    command: [ "-config.file=/etc/promtail.yml" ]
+  grafana-agent:
+    image: grafana/agent
+    container_name: grafana-agent
+    command:
+      - --config.file=/etc/agent/agent.yml
     environment:
       TZ: Asia/Tokyo
     volumes:
-      - ./config/promtail.yml:/etc/promtail.yml:ro
+      - ./agent/agent.yml:/etc/agent/agent.yml:lo
+      - agent-store:/etc/agent/data
       - app-logs:/var/logs
     networks:
       - agent
@@ -32,9 +34,26 @@ services:
       - datasources_external
     ports:
       - "9080:9080"
+      - "9411"     # zipkin receiver for Backend
+#  promtail:
+#    image: grafana/promtail
+#    container_name: promtail
+#    command: [ "-config.file=/etc/promtail.yml" ]
+#    environment:
+#      TZ: Asia/Tokyo
+#    volumes:
+#      - ./config/promtail.yml:/etc/promtail.yml:ro
+#      - app-logs:/var/logs
+#    networks:
+#      - agent
+#      - app
+#      - datasources_external
+#    ports:
+#      - "9080:9080"
 volumes:
   app-logs:
     driver: local
+  agent-store:
 networks:
   # アプリのネットワーク。ホストから http:localhost:8080 にアクセスするため公開
   app:

--- a/docker/backend/compose.yml
+++ b/docker/backend/compose.yml
@@ -13,7 +13,7 @@ services:
       - app
       - db_external
       - redis_external
-#      - datasources_external  # otel-exporter-zipkin で Tempoにアクセスするため
+    #      - datasources_external  # otel-exporter-zipkin で Tempoにアクセスするため
     ports:
       - "8080:8080"
       - "8081:8081"
@@ -31,9 +31,11 @@ services:
     networks:
       - agent
       - app
+      - db_external
+      - redis_external
       - datasources_external
     ports:
-      - "9080:9080"
+      - "12345:12345"
       - "9411"     # zipkin receiver for Backend
 #  promtail:
 #    image: grafana/promtail

--- a/docker/backend/compose.yml
+++ b/docker/backend/compose.yml
@@ -13,7 +13,6 @@ services:
       - app
       - db_external
       - redis_external
-    #      - datasources_external  # otel-exporter-zipkin で Tempoにアクセスするため
     ports:
       - "8080:8080"
       - "8081:8081"
@@ -37,21 +36,6 @@ services:
     ports:
       - "12345:12345"
       - "9411"     # zipkin receiver for Backend
-#  promtail:
-#    image: grafana/promtail
-#    container_name: promtail
-#    command: [ "-config.file=/etc/promtail.yml" ]
-#    environment:
-#      TZ: Asia/Tokyo
-#    volumes:
-#      - ./config/promtail.yml:/etc/promtail.yml:ro
-#      - app-logs:/var/logs
-#    networks:
-#      - agent
-#      - app
-#      - datasources_external
-#    ports:
-#      - "9080:9080"
 volumes:
   app-logs:
     driver: local

--- a/docker/grafana-stack/compose.yml
+++ b/docker/grafana-stack/compose.yml
@@ -1,18 +1,4 @@
 services:
-  #  prometheus:
-  #    image: prom/prometheus
-  #    container_name: prometheus
-  #    command:
-  #      - --enable-feature=exemplar-storage
-  #      - --config.file=/etc/prometheus/prometheus.yml
-  #    environment:
-  #      TZ: Asia/Tokyo
-  #    volumes:
-  #      - ./config/prometheus.yml:/etc/prometheus/prometheus.yml:ro
-  #    networks:
-  #      - datasource
-  #    ports:
-  #      - "9090:9090"
   mimir:
     image: grafana/mimir
     container_name: mimir
@@ -40,7 +26,6 @@ services:
     ports:
       - "3200:3200"   # tempo
       - "4317:4317"   # for Grafana Agent exports via gRPC using OTLP
-  #      - "9411:9411"   # zipkin
   loki:
     image: grafana/loki
     container_name: loki

--- a/docker/grafana-stack/compose.yml
+++ b/docker/grafana-stack/compose.yml
@@ -1,18 +1,31 @@
 services:
-  prometheus:
-    image: prom/prometheus
-    container_name: prometheus
-    command:
-      - --enable-feature=exemplar-storage
-      - --config.file=/etc/prometheus/prometheus.yml
+  #  prometheus:
+  #    image: prom/prometheus
+  #    container_name: prometheus
+  #    command:
+  #      - --enable-feature=exemplar-storage
+  #      - --config.file=/etc/prometheus/prometheus.yml
+  #    environment:
+  #      TZ: Asia/Tokyo
+  #    volumes:
+  #      - ./config/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+  #    networks:
+  #      - datasource
+  #    ports:
+  #      - "9090:9090"
+  mimir:
+    image: grafana/mimir
+    container_name: mimir
+    command: [ "-config.file=/etc/mimir.yml" ]
     environment:
       TZ: Asia/Tokyo
     volumes:
-      - ./config/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./config/mimir.yml:/etc/mimir.yml:ro
+      - mimir-storage:/tmp/mimir
     networks:
       - datasource
     ports:
-      - "9090:9090"
+      - "9009:9009"
   tempo:
     image: grafana/tempo
     container_name: tempo
@@ -26,7 +39,8 @@ services:
       - datasource
     ports:
       - "3200:3200"   # tempo
-      - "9411:9411"   # zipkin
+      - "4317:4317"   # for Grafana Agent exports via gRPC using OTLP
+  #      - "9411:9411"   # zipkin
   loki:
     image: grafana/loki
     container_name: loki
@@ -54,6 +68,7 @@ services:
       - "3000:3000"
 volumes:
   grafana-storage:
+  mimir-storage:
   tempo-data:
 networks:
   # Grafanaのネットワーク
@@ -61,7 +76,7 @@ networks:
     driver: bridge
     internal: false
     name: grafana_network
-  # GrafanaのDataSources(Prometheus, Tempo, Loki)のネットワーク。SpringBootActuator と GrafanaAgentからアクセスするために公開
+  # GrafanaのDataSources(Prometheus, Mimir, Tempo, Loki)のネットワーク。SpringBootActuator と GrafanaAgentからアクセスするために公開
   datasource:
     driver: bridge
     internal: false

--- a/docker/grafana-stack/config/mimir.yml
+++ b/docker/grafana-stack/config/mimir.yml
@@ -1,0 +1,45 @@
+multitenancy_enabled: false
+
+limits:
+  max_global_exemplars_per_user: 100000
+
+blocks_storage:
+  backend: filesystem
+  bucket_store:
+    sync_dir: /tmp/mimir/tsdb-sync
+  filesystem:
+    dir: /tmp/mimir/data/tsdb
+  tsdb:
+    dir: /tmp/mimir/tsdb
+
+compactor:
+  data_dir: /tmp/mimir/compactor
+  sharding_ring:
+    kvstore:
+      store: memberlist
+
+distributor:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: memberlist
+
+ingester:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: memberlist
+    replication_factor: 1
+
+ruler_storage:
+  backend: filesystem
+  filesystem:
+    dir: /tmp/mimir/rules
+
+server:
+  http_listen_port: 9009
+  log_level: info
+
+store_gateway:
+  sharding_ring:
+    replication_factor: 1

--- a/docker/grafana-stack/config/tempo.yml
+++ b/docker/grafana-stack/config/tempo.yml
@@ -1,9 +1,9 @@
 server:
   http_listen_port: 3200
 
-distributor:
-  receivers:
-    zipkin:
+#distributor:
+#  receivers:
+#    zipkin:
 
 storage:
   trace:

--- a/docker/grafana-stack/config/tempo.yml
+++ b/docker/grafana-stack/config/tempo.yml
@@ -6,7 +6,6 @@ distributor:
     otlp:
       protocols:
         grpc:
-#    zipkin:
 
 storage:
   trace:

--- a/docker/grafana-stack/config/tempo.yml
+++ b/docker/grafana-stack/config/tempo.yml
@@ -1,8 +1,11 @@
 server:
   http_listen_port: 3200
 
-#distributor:
-#  receivers:
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
 #    zipkin:
 
 storage:

--- a/docker/grafana-stack/grafana/provisioning/datasources/datasource.yml
+++ b/docker/grafana-stack/grafana/provisioning/datasources/datasource.yml
@@ -1,16 +1,16 @@
 apiVersion: 1
 
 datasources:
-  - name: Prometheus
+  - name: Prometheus(Mimir)
     type: prometheus
     access: proxy
-    url: http://host.docker.internal:9090
+    url: http://host.docker.internal:9009/prometheus
     editable: false
     jsonData:
       httpMethod: POST
       manageAlerts: true
-      prometheusType: Prometheus
-      prometheusVersion: 2.43.0
+      prometheusType: Mimir
+      prometheusVersion: 2.7.x
       exemplarTraceIdDestinations:
         - datasourceUid: Tempo
           name: trace_id
@@ -31,7 +31,7 @@ datasources:
         filterByTraceID: true
         filterBYSpanID: false
       serviceMap:
-        datasourceUid: 'Prometheus'
+        datasourceUid: 'Prometheus(Mimir)'
       search:
         hide: false
       nodeGraph:

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -45,7 +45,8 @@ management:
       probability: 1.0
   zipkin:
     tracing:
-      endpoint: http://tempo:9411
+      #      endpoint: http://tempo:9411
+      endpoint: http://grafana-agent:9411
   metrics:
     tags:
       application: app

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -45,7 +45,6 @@ management:
       probability: 1.0
   zipkin:
     tracing:
-      #      endpoint: http://tempo:9411
       endpoint: http://grafana-agent:9411
   metrics:
     tags:


### PR DESCRIPTION
## 概要

より効率的かつ正確なデータ収集が可能になるように対応しました

* Backendで収集する全てのTelemetryデータをGrafana Agentで収集し、Grafana Stackへ転送するように切り替えました。
* Metricsの管理をPrometheusからMimirに変更しました。
* PostgreSQLとRedisのネットワークにアタッチされたagentによって、PostgreSQLサーバーとRedisサーバーのMetricsも収集するようにしました。


